### PR TITLE
Add stylized landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Connectors Landing
 
-This repository contains the starting files for the Connectors Landing page.
+A simple landing page showcasing my skills in building custom ChatGPT connectors.
+
+## Development
+
+Open `index.html` in your browser to view the page. The styles are defined in `style.css` and basic animations in `script.js`.

--- a/index.html
+++ b/index.html
@@ -1,13 +1,53 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Connectors Landing</title>
-    <link rel="stylesheet" href="style.css">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Connecteurs personnalisés – Grégory</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Welcome to Connectors Landing</h1>
-    <script src="script.js"></script>
+<header class="hero">
+  <div class="container">
+    <h1 data-animate>Connectez vos outils en toute simplicité</h1>
+    <p data-animate>Intégrations sur-mesure pour gagner du temps et réduire vos coûts</p>
+    <a href="#contact" class="cta" data-animate>Planifiez un appel</a>
+  </div>
+</header>
+
+<section id="benefits" class="section">
+  <h2 data-animate>Vos gains immédiats</h2>
+  <div class="grid">
+    <article class="card" data-animate><h3>Efficacité</h3><p>Réduisez les tâches répétitives.</p></article>
+    <article class="card" data-animate><h3>Sécurité</h3><p>Garantissez la fiabilité des échanges de données.</p></article>
+    <article class="card" data-animate><h3>Évolutivité</h3><p>Faites évoluer vos flux sans frein technique.</p></article>
+  </div>
+</section>
+
+<section id="proof" class="section alt">
+  <h2 data-animate>Ils font déjà confiance</h2>
+  <div class="logos" data-animate>
+    <img src="logo1.svg" alt="Logo 1">
+    <img src="logo2.svg" alt="Logo 2">
+    <img src="logo3.svg" alt="Logo 3">
+  </div>
+</section>
+
+<section id="contact" class="section">
+  <h2 data-animate>Discutons de votre projet</h2>
+  <form id="lead">
+    <input type="text" name="name" placeholder="Votre nom" required>
+    <input type="email" name="email" placeholder="Votre email" required>
+    <button type="submit" class="cta">Envoyer</button>
+  </form>
+</section>
+
+<footer class="footer">
+  <p>© 2025 Grégory – Connecteurs personnalisés</p>
+</footer>
+<script type="module" src="script.js"></script>
 </body>
 </html>

--- a/logo1.svg
+++ b/logo1.svg
@@ -1,0 +1,4 @@
+<svg width="80" height="40" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="40" fill="#4b00ae" />
+  <text x="40" y="25" fill="white" font-size="18" text-anchor="middle" font-family="Arial">A</text>
+</svg>

--- a/logo2.svg
+++ b/logo2.svg
@@ -1,0 +1,4 @@
+<svg width="80" height="40" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="40" fill="#ff5700" />
+  <text x="40" y="25" fill="white" font-size="18" text-anchor="middle" font-family="Arial">B</text>
+</svg>

--- a/logo3.svg
+++ b/logo3.svg
@@ -1,0 +1,4 @@
+<svg width="80" height="40" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="40" fill="#1d1d1d" />
+  <text x="40" y="25" fill="white" font-size="18" text-anchor="middle" font-family="Arial">C</text>
+</svg>

--- a/script.js
+++ b/script.js
@@ -1,2 +1,25 @@
-// Add JavaScript for interactivity
-console.log('Connectors Landing loaded');
+// Simple animation for elements with data-animate attribute
+const elements = document.querySelectorAll('[data-animate]');
+
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('visible');
+      observer.unobserve(entry.target);
+    }
+  });
+}, {
+  threshold: 0.1
+});
+
+elements.forEach(el => observer.observe(el));
+
+// Placeholder form submission
+const form = document.getElementById('lead');
+if (form) {
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    alert('Merci! Je vous recontacterai rapidement.');
+    form.reset();
+  });
+}

--- a/style.css
+++ b/style.css
@@ -1,4 +1,91 @@
-/* Add styles for the landing page */
+/* Base styles */
 body {
-    font-family: Arial, sans-serif;
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  line-height: 1.6;
+  color: #333;
+  background: #f7f7f7;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+/* Hero section */
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  height: 100vh;
+  background: linear-gradient(135deg, #1d1d1d, #4b00ae);
+  color: #fff;
+}
+
+.cta {
+  display: inline-block;
+  margin-top: 1.5rem;
+  padding: 0.75rem 2rem;
+  background: #ff5700;
+  color: #fff;
+  border-radius: 50px;
+  text-decoration: none;
+  transition: background 0.3s ease;
+}
+
+.cta:hover {
+  background: #e04500;
+}
+
+/* Sections */
+.section {
+  padding: 4rem 1rem;
+  background: #fff;
+  text-align: center;
+}
+
+.section.alt {
+  background: #eee;
+}
+
+.grid {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.card {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  flex: 1 1 200px;
+}
+
+.logos img {
+  max-height: 40px;
+  margin: 0 1rem;
+}
+
+.footer {
+  background: #1d1d1d;
+  color: #fff;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
+/* Animations */
+[data-animate] {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+[data-animate].visible {
+  opacity: 1;
+  transform: translateY(0);
 }


### PR DESCRIPTION
## Summary
- create a landing page to advertise ChatGPT connector skills
- add modern styles and animations
- add placeholder logos and simple form submission
- update README with brief instructions

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea19e3488328ac8f9a809c29aff7